### PR TITLE
add ruby defaults

### DIFF
--- a/frontside/ruby.el
+++ b/frontside/ruby.el
@@ -1,0 +1,10 @@
+(prelude-require-packages '(bundler rspec-mode))
+
+(add-to-list 'auto-mode-alist '("Gemfile" . ruby-mode))
+(add-to-list 'auto-mode-alist '("\\.gemspec\\'" . ruby-mode))
+
+(add-hook 'ruby-mode-hook 'prelude-enable-whitespace)
+
+(custom-set-variables
+ ;; don't indent like crazy.
+ '(ruby-deep-arglist nil))


### PR DESCRIPTION
This adds basic support for ruby development.
- bring in `bundler-mode` and `rspec-mode`
- load `Gemfile` and `*.gemspec` in `ruby-mode`
- don't do crazy indentation when you put args on a new line
