### PR TITLE
automatically load rspec snippets

### DIFF
--- a/frontside/ruby.el
+++ b/frontside/ruby.el
@@ -1,5 +1,9 @@
 (prelude-require-packages '(bundler rspec-mode))
 
+;; rspec-mode makes you explicitly require snippets nowadays
+(eval-after-load 'rspec-mode
+  '(rspec-install-snippets))
+
 (add-to-list 'auto-mode-alist '("Gemfile" . ruby-mode))
 (add-to-list 'auto-mode-alist '("\\.gemspec\\'" . ruby-mode))
 


### PR DESCRIPTION
rspec-mode changed to an opt-in strategy for loading your snippets in
case you use custom snippets for rspec. We don't so let's opt the hell
in.
