### PR TITLE
always split horizontally.

### DIFF
--- a/frontside/frontside.el
+++ b/frontside/frontside.el
@@ -15,7 +15,6 @@
 
 ;;(disable-theme 'zenburn)
 (prelude-require-packages '(frame-fns frame-cmds))
-(global-set-key (kbd "<s-return>") 'toggle-frame-maximized)
 
 ;; YAS snippets everywhere bro.
 (prelude-require-package 'yasnippet)

--- a/frontside/windowing.el
+++ b/frontside/windowing.el
@@ -1,0 +1,7 @@
+;; Command + Enter to toggle whether the Emacs frame is maximized
+;; Note: does nothing in terminal mode.
+(global-set-key (kbd "<s-return>") 'toggle-frame-maximized)
+
+;; Split horizontally when opening a new window from a command
+;; whenever possible.
+(setq split-height-threshold nil)


### PR DESCRIPTION
It seems to be the right thing to do almost always. This also splits out
anytihng to do with windowing commands into its own module.
