### PR TITLE
no need for menu-bar when in terminal mode.

### DIFF
--- a/frontside/windowing.el
+++ b/frontside/windowing.el
@@ -18,4 +18,8 @@ new windows will each be 180 columns wide, and sit just below the threshold.
 
 ;; recaculate split-width-threshold with every change
 (add-hook 'window-configuration-change-hook
- 'frontside-windowing-adjust-split-width-threshold)
+          'frontside-windowing-adjust-split-width-threshold)
+
+;; disable window-system in terminal mode
+(unless window-system
+  (menu-bar-mode -1))


### PR DESCRIPTION
![1__emacsclient](https://cloud.githubusercontent.com/assets/4205/7822513/96d49dba-03bb-11e5-8d42-225b159606a6.png)

There are ways to use the menu in terminal mode, but not with the mouse, so it's pretty distracting.
