### PR TITLE
enable js2-refactor in js2-mode

### DIFF
--- a/frontside/javascript.el
+++ b/frontside/javascript.el
@@ -5,6 +5,7 @@
 ;;
 ;; all refactorings start with C-c C-r (for refactor!)
 (js2r-add-keybindings-with-prefix "C-c C-r")
+(add-hook 'js2-mode-hook 'js2-refactor-mode)
 
 (custom-set-variables '(js-indent-level 2)
                       '(js2-basic-offset 2))


### PR DESCRIPTION
Later versions of js2-refactor mode are opt-in, whereas before it
registered itself to always be on in js2-mode, you have to automatically
load it. This adds js2-refactor-mode to the js2-mode hook.
