### PR TITLE
Bind C-n and C-p in vertical completion.

### DIFF
--- a/frontside/frontside.el
+++ b/frontside/frontside.el
@@ -105,6 +105,7 @@
 ;; make ido choices appear vertically.
 (prelude-require-package 'ido-vertical-mode)
 (ido-vertical-mode)
+(setq ido-vertical-define-keys 'C-n-and-C-p-only)
 
 ;; Line numbers always on in prog-mode
 (add-hook 'prog-mode-hook 'linum-mode)


### PR DESCRIPTION
As of version 1.0 ido-vertical-mode does not bind C-n and C-p to
`ido-next-match` and `ido-previous-match`. Not only is that what we're
used to, but it is also the most intuitive binding for emacs users.

See https://github.com/creichert/ido-vertical-mode.el#alternative-key-bindings for details.
